### PR TITLE
fix display wrong source lines

### DIFF
--- a/peda.py
+++ b/peda.py
@@ -5203,8 +5203,7 @@ class PEDACmd(object):
         try :
             if not hasattr(self,"source") or not hasattr(self,"filename") or filename != self.filename:
                 with open(filename) as source_file :
-                    self.source = source_file.read()
-                    self.source_lines = self.source.splitlines()
+                    self.source_lines = source_file.readlines()
                 self.filename = filename
         except Exception as e :
         #    msg("Cannot display %s" % filename)


### PR DESCRIPTION
Note that there's a difference between `readlines` and `splitlines`.
See https://docs.python.org/3/library/stdtypes.html#str.splitlines
`str.splitlines` will also split some strange characters like `\x0c`, but `readlines` will only recognize `\n`.